### PR TITLE
Edited main message to better supress non-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The table below shows the success rate of the AI functions with different GPT mo
 | Description               | GPT-4 Result | GPT-3.5-turbo Result | Reason |
 |---------------------------|--------------|----------------------|--------|
 | Generate fake people      | PASSED       | FAILED               | Incorrect response format |
-| Generate Random Password  | FAILED       | FAILED               | Incorrect response format |
+| Generate Random Password  | PASSED       | PASSED               | N/A |
 | Calculate area of triangle| FAILED       | FAILED               | Incorrect float value (GPT-4), Incorrect response format (GPT-3.5-turbo) |
 | Calculate the nth prime number | PASSED  | PASSED               | N/A    |
 | Encrypt text              | PASSED       | PASSED               | N/A    |

--- a/ai_functions.py
+++ b/ai_functions.py
@@ -3,7 +3,7 @@ import openai
 def ai_function(function, args, description, model = "gpt-4"):
     # parse args to comma separated string
     args = ", ".join(args)
-    messages = [{"role": "system", "content": f"You are now the following python function: ```# {description}\n{function}```\n\nOnly respond with your `return` value. no verbose, no chat."},{"role": "user", "content": args}]
+    messages = [{"role": "system", "content": f"You are now the following python function: ```# {description}\n{function}```\n\nOnly respond with your `return` value. Do not include any other explanatory text in your response."},{"role": "user", "content": args}]
 
     response = openai.ChatCompletion.create(
         model=model,


### PR DESCRIPTION
This PR addresses Issue #5 

In `ai_functions.py` the enumeration of what not to return (`no verbose, no chat.`) leaves room for interpretation, notably in gpt-3.5-turbo. Notably `test_2` would fail due to a response of "My return value is: `q#8^&jL@5$zX`"

In my other work, I have found that a more explicit directive of `Do not include any other explanatory text in your response.` generated better results. 

This pull request changes that initial directive, and updates the `README` to show Test 2 passing under both models.