### PR TITLE
Edited test_1 prompt to pass under gpt-3.5-turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The table below shows the success rate of the AI functions with different GPT mo
 
 | Description               | GPT-4 Result | GPT-3.5-turbo Result | Reason |
 |---------------------------|--------------|----------------------|--------|
-| Generate fake people      | PASSED       | FAILED               | Incorrect response format |
+| Generate fake people      | PASSED       | PASSED               | N/A |
 | Generate Random Password  | PASSED       | PASSED               | N/A |
 | Calculate area of triangle| FAILED       | FAILED               | Incorrect float value (GPT-4), Incorrect response format (GPT-3.5-turbo) |
 | Calculate the nth prime number | PASSED  | PASSED               | N/A    |

--- a/test_ai_function.py
+++ b/test_ai_function.py
@@ -45,7 +45,7 @@ def run_tests(model):
 def test_1(model):
     function_string = "def fake_people(n: int) -> list[dict]:"
     args = ["4"]
-    description_string = """Generates n examples of fake data representing people, 
+    description_string = """Generates n examples of fake data representing people in valid JSON format using double quotes not single quotes, 
             each with a name and an age."""
 
     result_string = ai_functions.ai_function(function_string, args, description_string, model)


### PR DESCRIPTION
test_1 under gpt-3.5-turbo was failing because the model was returning single quotes instead of the proper double quotes in the JSON:

```shell
=-=-=- Running test: test_1 - Generate fake people with model gpt-3.5-turbo -=-=-=
GPT RAW:  [{'name': 'John', 'age': 25},
 {'name': 'Jane', 'age': 32},
 {'name': 'Bob', 'age': 19},
 {'name': 'Alice', 'age': 47}]
Output: [{'name': 'John', 'age': 25},
 {'name': 'Jane', 'age': 32},
 {'name': 'Bob', 'age': 19},
 {'name': 'Alice', 'age': 47}]
Testing if result is a a string...
Testing if result can be parsed as a list of dictionaries...
test_1: FAILED - 
``` 

Perhaps it was encountering a similar issue to this post -- single/double quotes are interchangeable in Python, but not JSON: https://stackoverflow.com/questions/4162642/single-vs-double-quotes-in-json

I have made a small edit to the `description_string` for test_1, reminding GPT that JSON should have double quotes; to help disambiguate Python formatting vs. JSON formatting.

I have edited the README as well.